### PR TITLE
feat: Add Forge as LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 OPENAI_API_KEY=
 GROQ_API_KEY=
+FORGE_API_KEY=
+FORGE_API_BASE=https://api.forge.tensorblock.co/v1

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ The agent's ability to break down and solve such complex queries demonstrates it
    ```
    OPENAI_API_KEY=
    GROQ_API_KEY=
+   FORGE_API_KEY=
+   FORGE_API_BASE=https://api.forge.tensorblock.co/v1
    ```
    you can look at the `.env.example` file for reference.
 

--- a/functions_for_pipeline.py
+++ b/functions_for_pipeline.py
@@ -22,18 +22,20 @@ from helper_functions import escape_quotes, text_wrap
 
 
 """
-Set the environment variables for the API keys.
+Resolve API credentials without mutating global environment variables.
+When Forge is configured, its key/base take priority; otherwise fall back to
+the standard OPENAI_API_KEY.
 """
 load_dotenv()
 os.environ["PYDEVD_WARN_EVALUATION_TIMEOUT"] = "100000"
 forge_api_key = os.getenv("FORGE_API_KEY")
 forge_api_base = os.getenv("FORGE_API_BASE") or "https://api.forge.tensorblock.co/v1"
 if forge_api_key:
-    os.environ["OPENAI_API_KEY"] = forge_api_key
-    os.environ["OPENAI_BASE_URL"] = forge_api_base
-    os.environ["OPENAI_API_BASE"] = forge_api_base
-elif os.getenv("OPENAI_API_KEY"):
-    os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
+    _openai_api_key = forge_api_key
+    _openai_api_base = forge_api_base
+else:
+    _openai_api_key = os.getenv("OPENAI_API_KEY")
+    _openai_api_base = None  # use LangChain / OpenAI SDK default
 # groq_api_key = os.getenv('GROQ_API_KEY')
 
 def _forge_model_name(model_name: str) -> str:
@@ -46,13 +48,22 @@ def create_chat_llm(**kwargs):
     model_name = kwargs.get("model_name")
     if model_name:
         kwargs["model_name"] = _forge_model_name(model_name)
+    if _openai_api_key:
+        kwargs.setdefault("openai_api_key", _openai_api_key)
+    if _openai_api_base:
+        kwargs.setdefault("openai_api_base", _openai_api_base)
     return ChatOpenAI(**kwargs)
 
 
 def create_embeddings():
+    embed_kwargs = {}
+    if _openai_api_key:
+        embed_kwargs["openai_api_key"] = _openai_api_key
+    if _openai_api_base:
+        embed_kwargs["openai_api_base"] = _openai_api_base
     if forge_api_key:
-        return OpenAIEmbeddings(model=_forge_model_name("text-embedding-3-small"))
-    return OpenAIEmbeddings()
+        embed_kwargs["model"] = _forge_model_name("text-embedding-3-small")
+    return OpenAIEmbeddings(**embed_kwargs)
 
 
 

--- a/functions_for_pipeline.py
+++ b/functions_for_pipeline.py
@@ -26,13 +26,38 @@ Set the environment variables for the API keys.
 """
 load_dotenv()
 os.environ["PYDEVD_WARN_EVALUATION_TIMEOUT"] = "100000"
-os.environ["OPENAI_API_KEY"] = os.getenv('OPENAI_API_KEY')
+forge_api_key = os.getenv("FORGE_API_KEY")
+forge_api_base = os.getenv("FORGE_API_BASE") or "https://api.forge.tensorblock.co/v1"
+if forge_api_key:
+    os.environ["OPENAI_API_KEY"] = forge_api_key
+    os.environ["OPENAI_BASE_URL"] = forge_api_base
+    os.environ["OPENAI_API_BASE"] = forge_api_base
+elif os.getenv("OPENAI_API_KEY"):
+    os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
 # groq_api_key = os.getenv('GROQ_API_KEY')
+
+def _forge_model_name(model_name: str) -> str:
+    if forge_api_key and model_name and "/" not in model_name:
+        return f"OpenAI/{model_name}"
+    return model_name
+
+
+def create_chat_llm(**kwargs):
+    model_name = kwargs.get("model_name")
+    if model_name:
+        kwargs["model_name"] = _forge_model_name(model_name)
+    return ChatOpenAI(**kwargs)
+
+
+def create_embeddings():
+    if forge_api_key:
+        return OpenAIEmbeddings(model=_forge_model_name("text-embedding-3-small"))
+    return OpenAIEmbeddings()
 
 
 
 def create_retrievers():
-    embeddings = OpenAIEmbeddings()
+    embeddings = create_embeddings()
     chunks_vector_store =  FAISS.load_local("chunks_vector_store", embeddings, allow_dangerous_deserialization=True)
     chapter_summaries_vector_store =  FAISS.load_local("chapter_summaries_vector_store", embeddings, allow_dangerous_deserialization=True)
     book_quotes_vectorstore =  FAISS.load_local("book_quotes_vectorstore", embeddings, allow_dangerous_deserialization=True)
@@ -103,7 +128,7 @@ def create_keep_only_relevant_content_chain():
     )
 
 
-    keep_only_relevant_content_llm = ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    keep_only_relevant_content_llm = create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
     keep_only_relevant_content_chain = keep_only_relevant_content_prompt | keep_only_relevant_content_llm.with_structured_output(KeepRelevantContent)
     return keep_only_relevant_content_chain
 
@@ -141,7 +166,7 @@ def create_question_answer_from_context_cot_chain():
     class QuestionAnswerFromContext(BaseModel):
         answer_based_on_content: str = Field(description="generates an answer to a query based on a given context.")
 
-    question_answer_from_context_llm = ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    question_answer_from_context_llm = create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
 
 
     question_answer_cot_prompt_template = """ 
@@ -237,7 +262,7 @@ def create_is_relevant_content_chain():
 
     # is_relevant_json_parser = JsonOutputParser(pydantic_object=Relevance)
     # is_relevant_llm = ChatGroq(temperature=0, model_name="llama3-70b-8192", groq_api_key=groq_api_key, max_tokens=4000)
-    is_relevant_llm = ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    is_relevant_llm = create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
 
     is_relevant_content_prompt = PromptTemplate(
         template=is_relevant_content_prompt_template,
@@ -284,7 +309,7 @@ def create_is_grounded_on_facts_chain():
         """
         grounded_on_facts: bool = Field(description="Answer is grounded in the facts, 'yes' or 'no'")
 
-    is_grounded_on_facts_llm = ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    is_grounded_on_facts_llm = create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
     is_grounded_on_facts_prompt_template = """You are a fact-checker that determines if the given answer {answer} is grounded in the given context {context}
     you don't mind if it doesn't make sense, as long as it is grounded in the context.
     output a json containing the answer to the question, and appart from the json format don't output any additional text.
@@ -315,7 +340,7 @@ def create_can_be_answered_chain():
     )
 
     # can_be_answered_llm = ChatGroq(temperature=0, model_name="llama3-70b-8192", groq_api_key=groq_api_key, max_tokens=4000)
-    can_be_answered_llm = ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    can_be_answered_llm = create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
     can_be_answered_chain = answer_question_prompt | can_be_answered_llm.with_structured_output(QuestionAnswer)
     return can_be_answered_chain
 
@@ -340,7 +365,7 @@ def create_is_distilled_content_grounded_on_content_chain():
     )
 
     # is_distilled_content_grounded_on_content_llm = ChatGroq(temperature=0, model_name="llama3-70b-8192", groq_api_key=groq_api_key, max_tokens=4000)
-    is_distilled_content_grounded_on_content_llm =ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    is_distilled_content_grounded_on_content_llm =create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
 
     is_distilled_content_grounded_on_content_chain = is_distilled_content_grounded_on_content_prompt | is_distilled_content_grounded_on_content_llm.with_structured_output(IsDistilledContentGroundedOnContent)
     return is_distilled_content_grounded_on_content_chain
@@ -594,7 +619,7 @@ def create_plan_chain():
         input_variables=["question"], 
         )
 
-    planner_llm = ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    planner_llm = create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
 
     planner = planner_prompt | planner_llm.with_structured_output(Plan)
     return planner
@@ -619,7 +644,7 @@ def create_break_down_plan_chain():
         input_variables=["plan"],
     )
 
-    break_down_plan_llm = ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    break_down_plan_llm = create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
 
     break_down_plan_chain = break_down_plan_prompt | break_down_plan_llm.with_structured_output(Plan)
 
@@ -665,7 +690,7 @@ def create_replanner_chain():
         # partial_variables={"format_instructions": act_possible_results_parser.get_format_instructions()},
     )
 
-    replanner_llm = ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    replanner_llm = create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
 
 
 
@@ -706,7 +731,7 @@ def create_task_handler_chain():
         input_variables=["curr_task", "aggregated_context", "last_tool" "past_steps", "question"],
     )
 
-    task_handler_llm = ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    task_handler_llm = create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
     task_handler_chain = task_handler_prompt | task_handler_llm.with_structured_output(TaskHandlerOutput)
     return task_handler_chain
 
@@ -739,7 +764,7 @@ def create_anonymize_question_chain():
         partial_variables={"format_instructions": anonymize_question_parser.get_format_instructions()},
     )
 
-    anonymize_question_llm = ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    anonymize_question_llm = create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
     anonymize_question_chain = anonymize_question_prompt | anonymize_question_llm | anonymize_question_parser
     return anonymize_question_chain
 
@@ -761,7 +786,7 @@ def create_deanonymize_plan_chain():
         input_variables=["plan", "mapping"],
     )
 
-    de_anonymize_plan_llm = ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    de_anonymize_plan_llm = create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
     de_anonymize_plan_chain = de_anonymize_plan_prompt | de_anonymize_plan_llm.with_structured_output(DeAnonymizePlan)
     return de_anonymize_plan_chain
 
@@ -782,7 +807,7 @@ def create_can_be_answered_already_chain():
         input_variables=["question","context"],
     )
 
-    can_be_answered_already_llm = ChatOpenAI(temperature=0, model_name="gpt-4o", max_tokens=2000)
+    can_be_answered_already_llm = create_chat_llm(temperature=0, model_name="gpt-4o", max_tokens=2000)
     can_be_answered_already_chain = can_be_answered_already_prompt | can_be_answered_already_llm.with_structured_output(CanBeAnsweredAlready)
     return can_be_answered_already_chain
 


### PR DESCRIPTION
## Summary
Adds Forge API support by introducing `create_chat_llm()` and `create_embeddings()` factory functions that route requests through Forge's OpenAI-compatible API when `FORGE_API_KEY` is set. Replaces direct `ChatOpenAI()` calls with the factory to centralize provider configuration.

## Changes
- `.env.example`: Added `FORGE_API_KEY` and `FORGE_API_BASE` entries
- `README.md`: Documented Forge environment variables
- `functions_for_pipeline.py`: Added `create_chat_llm()`, `create_embeddings()`, and `_forge_model_name()` helpers; updated 13 LLM instantiation sites to use the factory

## Usage
```bash
# Set environment variables
export FORGE_API_KEY="your-forge-api-key"
# export FORGE_API_BASE="https://api.forge.tensorblock.co/v1"  # optional

# Run as usual — Forge is used automatically when FORGE_API_KEY is set
```

## Test Evidence
All existing tests pass. When `FORGE_API_KEY` is not set, behavior is identical to upstream.

I work at TensorBlock and will help maintain this integration.

---

## About Forge

[Forge](https://github.com/TensorBlock/forge) is an open-source middleware service for unified AI model provider management. It routes requests across 40+ AI providers with access to thousands of models through a single OpenAI-compatible API.

- Repo: https://github.com/TensorBlock/forge
- Docs: https://www.tensorblock.co/api-docs/overview